### PR TITLE
Opting out Sequelize from the server components bundling.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,7 @@ const nextConfig = {
 
         return config;
     },
+    serverExternalPackages: ["sequelize"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
Prior to this commit, the logs were spammed with:
> Critical dependency: the request of a dependency is an expression