### PR TITLE
Exchange idea of translating to native/studying pairs.

### DIFF
--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -14,8 +14,8 @@ async function pickTongue(tongueId: number): Promise<TonguePair> {
     // If there is no tongue pair currently, creates one.
     if (oldTonguePair === null) {
         newTonguePair = await TonguePair.create({
-            translateFromTongueId: 1,
-            translateToTongueId: tongueId,
+            nativeTongueId: 1,
+            studyingTongueId: tongueId,
         });
     }
 
@@ -23,8 +23,8 @@ async function pickTongue(tongueId: number): Promise<TonguePair> {
     else {
         const [createdTonguePair, created] = await TonguePair.findOrCreate({
             where: {
-                translateFromTongueId: oldTonguePair.translateFromTongueId,
-                translateToTongueId: tongueId,
+                nativeTongueId: oldTonguePair.nativeTongueId,
+                studyingTongueId: tongueId,
             },
         });
         newTonguePair = createdTonguePair;
@@ -40,11 +40,11 @@ async function pickTongueAndGetBack(
     "use server";
 
     let tonguePair = await pickTongue(tongueId);
-    let translateToTongue = await tonguePair.translateToTongue();
+    let studyingTongue = await tonguePair.studyingTongue();
     return {
-        id: translateToTongue.id,
-        tongueName: translateToTongue.tongueName,
-        flag: translateToTongue.flag,
+        id: studyingTongue.id,
+        tongueName: studyingTongue.tongueName,
+        flag: studyingTongue.flag,
     };
 }
 
@@ -67,7 +67,7 @@ export default async function Home() {
     const allTongues = await fetchAllTongues();
     const settings = await getSettings();
     const tonguePair = settings.tonguePair;
-    const initialTongueModel = tonguePair ? tonguePair.translateTo : null;
+    const initialTongueModel = tonguePair ? tonguePair.studying : null;
     const initialTongue = initialTongueModel
         ? {
               id: initialTongueModel.id,

--- a/src/db/helpers/settings.ts
+++ b/src/db/helpers/settings.ts
@@ -22,10 +22,7 @@ async function settingsGetter(): Promise<Settings> {
         },
         include: {
             association: "tonguePair",
-            include: [
-                { association: "translateFrom" },
-                { association: "translateTo" },
-            ],
+            include: [{ association: "native" }, { association: "studying" }],
         },
     });
     if (created) {

--- a/src/db/migrations/20241129232117-translate-to-native-studying.js
+++ b/src/db/migrations/20241129232117-translate-to-native-studying.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.renameColumn(
+                "TonguePairs",
+                "translateFromTongueId",
+                "nativeTongueId",
+                { transaction: t },
+            );
+            await queryInterface.renameColumn(
+                "TonguePairs",
+                "translateToTongueId",
+                "studyingTongueId",
+                { transaction: t },
+            );
+        });
+    },
+
+    async down(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (t) => {
+            await queryInterface.renameColumn(
+                "TonguePairs",
+                "nativeTongueId",
+                "translateFromTongueId",
+                { transaction: t },
+            );
+            await queryInterface.renameColumn(
+                "TonguePairs",
+                "studyingTongueId",
+                "translateToTongueId",
+                { transaction: t },
+            );
+        });
+    },
+};

--- a/src/db/models/tonguepair.ts
+++ b/src/db/models/tonguepair.ts
@@ -11,32 +11,32 @@ import sequelize from "./index";
 import Tongue from "./tongue";
 
 class TonguePair extends Model<
-    InferAttributes<TonguePair, { omit: "translateFrom" | "translateTo" }>,
+    InferAttributes<TonguePair, { omit: "nativeTongue" | "studyingTongue" }>,
     InferCreationAttributes<
         TonguePair,
-        { omit: "translateFrom" | "translateTo" }
+        { omit: "nativeTongue" | "studyingTongue" }
     >
 > {
     declare id: CreationOptional<number>;
 
-    declare translateFromTongueId: ForeignKey<Tongue["id"]>;
-    declare translateFrom: NonAttribute<Tongue>;
+    declare nativeTongueId: ForeignKey<Tongue["id"]>;
+    declare native: NonAttribute<Tongue>;
 
-    declare translateToTongueId: ForeignKey<Tongue["id"]>;
-    declare translateTo: NonAttribute<Tongue>;
+    declare studyingTongueId: ForeignKey<Tongue["id"]>;
+    declare studying: NonAttribute<Tongue>;
 
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
 
-    async translateFromTongue(): Promise<Tongue> {
+    async nativeTongue(): Promise<Tongue> {
         return Tongue.findOne({
-            where: { id: this.translateFromTongueId },
+            where: { id: this.nativeTongueId },
         });
     }
 
-    async translateToTongue(): Promise<Tongue> {
+    async studyingTongue(): Promise<Tongue> {
         return Tongue.findOne({
-            where: { id: this.translateToTongueId },
+            where: { id: this.studyingTongueId },
         });
     }
 }
@@ -48,7 +48,7 @@ TonguePair.init(
             autoIncrement: true,
             primaryKey: true,
         },
-        translateFromTongueId: {
+        nativeTongueId: {
             type: DataTypes.INTEGER,
             references: {
                 model: "Tongues",
@@ -58,7 +58,7 @@ TonguePair.init(
             onUpdate: "CASCADE",
             allowNull: false,
         },
-        translateToTongueId: {
+        studyingTongueId: {
             type: DataTypes.INTEGER,
             references: {
                 model: "Tongues",
@@ -79,29 +79,29 @@ TonguePair.init(
 );
 
 Tongue.hasMany(TonguePair, {
-    foreignKey: "translateFromTongueId",
+    foreignKey: "nativeTongueId",
 });
 Tongue.hasMany(TonguePair, {
-    foreignKey: "translateToTongueId",
+    foreignKey: "studyingTongueId",
 });
 TonguePair.belongsTo(Tongue, {
-    foreignKey: "translateFromTongueId",
-    as: "translateFrom",
+    foreignKey: "nativeTongueId",
+    as: "native",
 });
 TonguePair.belongsTo(Tongue, {
-    foreignKey: "translateToTongueId",
-    as: "translateTo",
+    foreignKey: "studyingTongueId",
+    as: "studying",
 });
 
 Tongue.belongsToMany(Tongue, {
     through: TonguePair,
-    foreignKey: "translateFromTongueId",
-    as: "translateToTongueId",
+    foreignKey: "nativeTongueId",
+    as: "studyingTongueId",
 });
 Tongue.belongsToMany(Tongue, {
     through: TonguePair,
-    foreignKey: "translateToTongueId",
-    as: "translateFromTongueId",
+    foreignKey: "studyingTongueId",
+    as: "nativeTongueId",
 });
 
 export default TonguePair;


### PR DESCRIPTION
It is easier to allow vocabulary to be grouped by the language that the user is studying, and the language that the user is native in, rather than grouping the vocabulary by the language from/to which the user is translating. This means that a single tongue pair can contain, for example, Chinese words to translate to English and English words to translate to Chinese.