### PR TITLE
Standardizing assocations.

### DIFF
--- a/src/app/vocab/page.tsx
+++ b/src/app/vocab/page.tsx
@@ -2,8 +2,7 @@
 
 import { getSettings, setSettings } from "src/db/helpers/settings";
 import TongueSelector from "./components/tongueselector/tongueselector";
-import TonguePair from "@models/tonguepair";
-import Tongue from "@models/tongue";
+import { Tongue, TonguePair } from "src/db/models";
 
 async function pickTongue(tongueId: number): Promise<TonguePair> {
     "use server";

--- a/src/db/helpers/settings.ts
+++ b/src/db/helpers/settings.ts
@@ -1,7 +1,6 @@
 import { cache } from "react";
 
-import Settings from "@models/settings";
-import TonguePair from "@models/tonguepair";
+import { Settings, TonguePair } from "src/db/models";
 
 // Possible options that can be passed to setSettings.
 interface SettingsSetter {

--- a/src/db/models/db-connection.ts
+++ b/src/db/models/db-connection.ts
@@ -1,0 +1,10 @@
+import { Sequelize } from "sequelize";
+import { SequelizeOptions } from "sequelize-typescript";
+import { options } from "../config/config.mjs";
+
+const dbOptions = <SequelizeOptions>options;
+dbOptions.dialectModule = require("sqlite3");
+
+const sequelize = new Sequelize(dbOptions);
+
+export default sequelize;

--- a/src/db/models/index.ts
+++ b/src/db/models/index.ts
@@ -1,10 +1,24 @@
-import { Sequelize } from "sequelize";
-import { SequelizeOptions } from "sequelize-typescript";
-import { options } from "../config/config.mjs";
+import { Tongue } from "./tongue";
+import { TonguePair } from "./tonguepair";
+import { Settings } from "./settings";
+import { Sheet } from "./sheet";
+import { Question } from "./question";
+import { SheetQuestion } from "./sheetquestion";
 
-const dbOptions = <SequelizeOptions>options;
-dbOptions.dialectModule = require("sqlite3");
+for (const model of [
+    Tongue,
+    TonguePair,
+    Settings,
+    Sheet,
+    Question,
+    SheetQuestion,
+]) {
+    model.associate();
+}
 
-const sequelize = new Sequelize(dbOptions);
-
-export default sequelize;
+export { Tongue } from "./tongue";
+export { TonguePair } from "./tonguepair";
+export { Settings } from "./settings";
+export { Sheet } from "./sheet";
+export { Question } from "./question";
+export { SheetQuestion } from "./sheetquestion";

--- a/src/db/models/question.ts
+++ b/src/db/models/question.ts
@@ -7,10 +7,10 @@ import {
     Model,
     NonAttribute,
 } from "sequelize";
-import sequelize from "./index";
-import TonguePair from "./tonguepair";
+import sequelize from "./db-connection";
+import { Sheet, SheetQuestion, TonguePair } from "../models";
 
-class Question extends Model<
+export class Question extends Model<
     InferAttributes<Question, { omit: "tonguePair" }>,
     InferCreationAttributes<Question, { omit: "tonguePair" }>
 > {
@@ -23,6 +23,22 @@ class Question extends Model<
 
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
+
+    static associate() {
+        Question.hasMany(SheetQuestion, {
+            foreignKey: "questionId",
+        });
+
+        Question.belongsTo(TonguePair, {
+            foreignKey: "tonguePairId",
+        });
+
+        Question.belongsToMany(Sheet, {
+            through: SheetQuestion,
+            foreignKey: "sheetId",
+            as: "questionId",
+        });
+    }
 }
 
 Question.init(
@@ -59,5 +75,3 @@ Question.init(
         timestamps: true,
     },
 );
-
-export default Question;

--- a/src/db/models/settings.ts
+++ b/src/db/models/settings.ts
@@ -7,10 +7,10 @@ import {
     Model,
     NonAttribute,
 } from "sequelize";
-import sequelize from "./index";
-import TonguePair from "./tonguepair";
+import sequelize from "./db-connection";
+import { TonguePair } from "../models";
 
-class Settings extends Model<
+export class Settings extends Model<
     InferAttributes<Settings, { omit: "tonguePair" }>,
     InferCreationAttributes<Settings, { omit: "tonguePair" }>
 > {
@@ -21,6 +21,13 @@ class Settings extends Model<
 
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
+
+    static associate() {
+        Settings.belongsTo(TonguePair, {
+            foreignKey: "tonguePairId",
+            as: "tonguePair",
+        });
+    }
 }
 
 Settings.init(
@@ -48,10 +55,3 @@ Settings.init(
         timestamps: true,
     },
 );
-
-Settings.belongsTo(TonguePair, {
-    foreignKey: "tonguePairId",
-    as: "tonguePair",
-});
-
-export default Settings;

--- a/src/db/models/sheet.ts
+++ b/src/db/models/sheet.ts
@@ -7,10 +7,10 @@ import {
     Model,
     NonAttribute,
 } from "sequelize";
-import sequelize from "./index";
-import TonguePair from "./tonguepair";
+import sequelize from "./db-connection";
+import { Question, SheetQuestion, TonguePair } from "../models";
 
-class Sheet extends Model<
+export class Sheet extends Model<
     InferAttributes<Sheet, { omit: "tonguePair" }>,
     InferCreationAttributes<Sheet, { omit: "tonguePair" }>
 > {
@@ -23,6 +23,22 @@ class Sheet extends Model<
 
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
+
+    static associate() {
+        Sheet.hasMany(SheetQuestion, {
+            foreignKey: "sheetId",
+        });
+
+        Sheet.belongsTo(TonguePair, {
+            foreignKey: "tonguePairId",
+        });
+
+        Sheet.belongsToMany(Question, {
+            through: SheetQuestion,
+            foreignKey: "questionId",
+            as: "sheetId",
+        });
+    }
 }
 Sheet.init(
     {
@@ -54,5 +70,3 @@ Sheet.init(
         timestamps: true,
     },
 );
-
-export default Sheet;

--- a/src/db/models/sheetquestion.ts
+++ b/src/db/models/sheetquestion.ts
@@ -7,12 +7,10 @@ import {
     Model,
     NonAttribute,
 } from "sequelize";
-import sequelize from "./index";
-import Sheet from "./sheet";
-import Question from "./question";
-import TonguePair from "./tonguepair";
+import sequelize from "./db-connection";
+import { Question, Sheet } from "../models";
 
-class SheetQuestion extends Model<
+export class SheetQuestion extends Model<
     InferAttributes<SheetQuestion, { omit: "sheet" | "question" }>,
     InferCreationAttributes<SheetQuestion, { omit: "sheet" | "question" }>
 > {
@@ -26,6 +24,15 @@ class SheetQuestion extends Model<
 
     declare createdAt: CreationOptional<Date>;
     declare updatedAt: CreationOptional<Date>;
+
+    static associate() {
+        SheetQuestion.belongsTo(Sheet, {
+            foreignKey: "sheetId",
+        });
+        SheetQuestion.belongsTo(Question, {
+            foreignKey: "questionId",
+        });
+    }
 }
 
 SheetQuestion.init(
@@ -62,40 +69,3 @@ SheetQuestion.init(
         timestamps: true,
     },
 );
-
-SheetQuestion.belongsTo(Sheet, {
-    foreignKey: "sheetId",
-});
-
-SheetQuestion.belongsTo(Question, {
-    foreignKey: "questionId",
-});
-
-Question.hasMany(SheetQuestion, {
-    foreignKey: "questionId",
-});
-
-Question.belongsTo(TonguePair, {
-    foreignKey: "tonguePairId",
-});
-
-Question.belongsToMany(Sheet, {
-    through: SheetQuestion,
-    foreignKey: "sheetId",
-    as: "questionId",
-});
-Sheet.hasMany(SheetQuestion, {
-    foreignKey: "sheetId",
-});
-
-Sheet.belongsTo(TonguePair, {
-    foreignKey: "tonguePairId",
-});
-
-Sheet.belongsToMany(Question, {
-    through: SheetQuestion,
-    foreignKey: "questionId",
-    as: "sheetId",
-});
-
-export default SheetQuestion;

--- a/src/db/models/tongue.ts
+++ b/src/db/models/tongue.ts
@@ -1,8 +1,8 @@
 import { Association, CreationOptional, DataTypes, Model } from "sequelize";
-import sequelize from "./index";
-import TonguePair from "./tonguepair";
+import sequelize from "./db-connection";
+import { TonguePair } from "../models";
 
-class Tongue extends Model {
+export class Tongue extends Model {
     declare id: CreationOptional<number>;
     declare tongueName: string;
     declare flag: string;
@@ -14,6 +14,25 @@ class Tongue extends Model {
         TonguePairsFrom: Association<Tongue, TonguePair>;
         TonguePairsTo: Association<Tongue, TonguePair>;
     };
+
+    static associate() {
+        Tongue.hasMany(TonguePair, {
+            foreignKey: "nativeTongueId",
+        });
+        Tongue.hasMany(TonguePair, {
+            foreignKey: "studyingTongueId",
+        });
+        Tongue.belongsToMany(Tongue, {
+            through: TonguePair,
+            foreignKey: "nativeTongueId",
+            as: "studyingTongueId",
+        });
+        Tongue.belongsToMany(Tongue, {
+            through: TonguePair,
+            foreignKey: "studyingTongueId",
+            as: "nativeTongueId",
+        });
+    }
 }
 
 Tongue.init(
@@ -39,5 +58,3 @@ Tongue.init(
         timestamps: true,
     },
 );
-
-export default Tongue;

--- a/src/db/models/tonguepair.ts
+++ b/src/db/models/tonguepair.ts
@@ -7,10 +7,10 @@ import {
     Model,
     NonAttribute,
 } from "sequelize";
-import sequelize from "./index";
-import Tongue from "./tongue";
+import sequelize from "./db-connection";
+import { Tongue } from "../models";
 
-class TonguePair extends Model<
+export class TonguePair extends Model<
     InferAttributes<TonguePair, { omit: "nativeTongue" | "studyingTongue" }>,
     InferCreationAttributes<
         TonguePair,
@@ -37,6 +37,17 @@ class TonguePair extends Model<
     async studyingTongue(): Promise<Tongue> {
         return Tongue.findOne({
             where: { id: this.studyingTongueId },
+        });
+    }
+
+    static associate() {
+        TonguePair.belongsTo(Tongue, {
+            foreignKey: "nativeTongueId",
+            as: "native",
+        });
+        TonguePair.belongsTo(Tongue, {
+            foreignKey: "studyingTongueId",
+            as: "studying",
         });
     }
 }
@@ -77,31 +88,3 @@ TonguePair.init(
         timestamps: true,
     },
 );
-
-Tongue.hasMany(TonguePair, {
-    foreignKey: "nativeTongueId",
-});
-Tongue.hasMany(TonguePair, {
-    foreignKey: "studyingTongueId",
-});
-TonguePair.belongsTo(Tongue, {
-    foreignKey: "nativeTongueId",
-    as: "native",
-});
-TonguePair.belongsTo(Tongue, {
-    foreignKey: "studyingTongueId",
-    as: "studying",
-});
-
-Tongue.belongsToMany(Tongue, {
-    through: TonguePair,
-    foreignKey: "nativeTongueId",
-    as: "studyingTongueId",
-});
-Tongue.belongsToMany(Tongue, {
-    through: TonguePair,
-    foreignKey: "studyingTongueId",
-    as: "nativeTongueId",
-});
-
-export default TonguePair;


### PR DESCRIPTION
Every model has a static method called associate which should be called from `models/index.db`, which is also the single point from which all models are imported, ensuring that associations are always performed before a model is handled.