### PR TITLE
Shrinking the promotion button.

### DIFF
--- a/src/app/vocab/[sheet]/components/question-editor/question-editor.module.css
+++ b/src/app/vocab/[sheet]/components/question-editor/question-editor.module.css
@@ -41,6 +41,8 @@
 
 .promoteanswer {
     padding-inline: 20px;
+    width: 20px;
+    text-align: center;
 }
 
 .promoteanswer:hover {


### PR DESCRIPTION
The promotion button is just an arrow, so it ought not to occupy much space.