### PR TITLE
Saving is not needed until another answer is added.

### DIFF
--- a/src/app/vocab/[sheet]/components/add-other-answer/add-other-answer.tsx
+++ b/src/app/vocab/[sheet]/components/add-other-answer/add-other-answer.tsx
@@ -32,10 +32,10 @@ export default function AddOtherAnswer() {
         const newOtherAnswers: string[] = Object.assign([], otherAnswers);
         newOtherAnswers.push(currentOtherAnswer.trim());
         setOtherAnswers(newOtherAnswers);
+        setSavePossible(true);
     }
 
     function updateNewAnswer(e: React.ChangeEvent<HTMLInputElement>) {
-        setSavePossible(true);
         setCurrentOtherAnswer(e.target.value);
     }
 


### PR DESCRIPTION
Previously, if one started adding another answer, it would immediately mark the form as needing saving. This is misleading. It should only need saving once the user finishes writing the answer and is no longer selecting the input.