### PR TITLE
Prevent demotion of empty answers.

### DIFF
--- a/src/app/vocab/[sheet]/components/other-answer/other-answer.tsx
+++ b/src/app/vocab/[sheet]/components/other-answer/other-answer.tsx
@@ -62,7 +62,11 @@ export default function EditOtherAnswer({
     if (answerI != editingOtherAnswerI) {
         const promote = () => {
             const newOtherAnswers: string[] = Object.assign([], otherAnswers);
-            newOtherAnswers[answerI] = answerEntryValue;
+            if (answerEntryValue.length > 0) {
+                newOtherAnswers[answerI] = answerEntryValue;
+            } else {
+                newOtherAnswers.splice(answerI, 1);
+            }
 
             setOtherAnswers(newOtherAnswers);
             setAnswerEntryValue(answer);


### PR DESCRIPTION
When the answer input is empty, and the user promotes another answer, the other answer is merely shifted into the main answer input, without creating a replacement other answer.