### PR TITLE
Removing reliance on punycode module.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3453,6 +3453,14 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/@rushstack/node-core-library/node_modules/uri-js": {
+            "name": "fast-uri",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+            "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rushstack/node-core-library/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -4451,6 +4459,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ajv/node_modules/uri-js": {
+            "name": "fast-uri",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+            "integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
             "dev": true,
             "license": "MIT"
         },
@@ -9864,16 +9880,6 @@
                 "once": "^1.3.1"
             }
         },
-        "node_modules/punycode": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11714,16 +11720,6 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
-            }
-        },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "punycode": "^2.1.0"
             }
         },
         "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
         "#root/*.ts": "./*.ts",
         "#root/*.css": "./*.css",
         "#root/*.svg": "./*.svg"
+    },
+    "overrides": {
+        "uri-js": "npm:fast-uri@^2.3.0"
     }
 }


### PR DESCRIPTION
Punycode is deprecated, but eslint is by default dependent on it.