### PR TITLE
Truncating percentage of vocab sheets complete.

### DIFF
--- a/src/app/tests/components/test-sheet-row/test-sheet-row.tsx
+++ b/src/app/tests/components/test-sheet-row/test-sheet-row.tsx
@@ -20,7 +20,7 @@ export default function TestSheetRow({ sheet }: TestSheetRowProps) {
     return (
         <tr onClick={clickSheet}>
             <td>{sheet.sheetName}</td>
-            <td>{sheet.progress * 100}%</td>
+            <td>{Math.floor(sheet.progress * 100)}%</td>
         </tr>
     );
 }


### PR DESCRIPTION
It is not necessary to display to the user their progress in any smaller increment than 1%.