### PR TITLE
Ensuring datetime of star is only obtained when question is finished.

### DIFF
--- a/src/app/tests/[sheet]/submit-answer/route.ts
+++ b/src/app/tests/[sheet]/submit-answer/route.ts
@@ -15,10 +15,7 @@ function markCorrect(result: Result) {
     if (result.current === result.goal) {
         result.current = 2;
         result.goal = 2;
-    }
-
-    if (result.gotStarAt === null) {
-        result.gotStarAt = new Date();
+        result.gotStarAt ??= new Date();
     }
 
     result.save();


### PR DESCRIPTION
Previously, there was a bug that meant answering a question correctly was sufficient to record a star's datetime. In reality, that is only true when the current score and goal on a star is two points.