### PR TITLE
Correcting the calculation of stars.

### DIFF
--- a/src/app/tests/[sheet]/helpers.ts
+++ b/src/app/tests/[sheet]/helpers.ts
@@ -98,6 +98,9 @@ export async function getNumberOfStars(sheet: Sheet): Promise<number> {
     let numberOfStars = 0;
     for (const result of results) {
         numberOfStars += result.stars;
+        if (result.current === 2 && result.goal === 2) {
+            numberOfStars++;
+        }
     }
 
     return numberOfStars;


### PR DESCRIPTION
Prior to this, the number of stars was potentially less than the actual number of stars. This is because stars are a sum of the stars column, in addition to the number of questions where current = goal = 2.