### PR TITLE
Correcting question-validity check.

### DIFF
--- a/src/app/vocab/[sheet]/components/answer-section/answer-section.tsx
+++ b/src/app/vocab/[sheet]/components/answer-section/answer-section.tsx
@@ -11,14 +11,12 @@ export default function AnswerSection() {
         pending,
         setAnswerEntryValue,
         setOtherAnswers,
-        setQuestionFormValid,
         setSavePossible,
     } = useContext(editSheetContext);
 
     let answerEntry: JSX.Element | null = null;
     const onChangeAnswer = (e: React.ChangeEvent<HTMLInputElement>) => {
         setSavePossible(true);
-        setQuestionFormValid(e.target.value.length > 0);
         setAnswerEntryValue(e.target.value);
     };
     const onBlurAnswer = () => {

--- a/src/app/vocab/[sheet]/components/question-editor/question-editor.tsx
+++ b/src/app/vocab/[sheet]/components/question-editor/question-editor.tsx
@@ -27,6 +27,17 @@ interface clickSaveQuestionResponseProps {
     questionText: string;
 }
 
+function questionIsValid(question: string, answerText: string | null): boolean {
+    if (question.length === 0) {
+        return false;
+    }
+    if (answerText.length === 0) {
+        return false;
+    }
+
+    return true;
+}
+
 export default function QuestionEditor() {
     const {
         allQuestions,
@@ -36,7 +47,6 @@ export default function QuestionEditor() {
         otherAnswers,
         pending,
         proposedQuestionText,
-        questionFormValid,
         savePossible,
         selectedQuestion,
         setAllQuestions,
@@ -44,7 +54,6 @@ export default function QuestionEditor() {
         setIsEditingQuestionText,
         setPending,
         setProposedQuestionText,
-        setQuestionFormValid,
         setSavePossible,
         setSelectedQuestion,
         sheetId,
@@ -178,9 +187,6 @@ export default function QuestionEditor() {
             return;
         }
 
-        setQuestionFormValid(
-            proposedQuestionText.length > 0 && answerEntryValue.length > 0,
-        );
         setProposedQuestionText(inputText);
         setSavePossible(true);
     };
@@ -200,9 +206,6 @@ export default function QuestionEditor() {
             return;
         }
 
-        setQuestionFormValid(
-            proposedQuestionText.length > 0 && answerEntryValue.length > 0,
-        );
         setProposedQuestionText(inputText);
         setSavePossible(true);
     };
@@ -225,7 +228,11 @@ export default function QuestionEditor() {
             <div className={styles.padsavebutton}>
                 {deleteButton}
                 <Button
-                    disabled={!savePossible || pending || !questionFormValid}
+                    disabled={
+                        !savePossible ||
+                        pending ||
+                        !questionIsValid(proposedQuestionText, answerEntryValue)
+                    }
                 >
                     Save question
                 </Button>

--- a/src/app/vocab/[sheet]/components/sheet-editor/sheet-editor.tsx
+++ b/src/app/vocab/[sheet]/components/sheet-editor/sheet-editor.tsx
@@ -31,7 +31,6 @@ export default function SheetEditor({ sheet, questions }: SheetEditorProps) {
         useState<string>("");
     const [isEditingQuestionText, setIsEditingQuestionText] =
         useState<boolean>(false);
-    const [questionFormValid, setQuestionFormValid] = useState<boolean>(true);
     const [otherAnswers, setOtherAnswers] = useState<string[]>([]);
     const [isAddingOtherAnswer, setIsAddingOtherAnswer] =
         useState<boolean>(false);
@@ -52,7 +51,6 @@ export default function SheetEditor({ sheet, questions }: SheetEditorProps) {
         otherAnswers,
         pending,
         proposedQuestionText,
-        questionFormValid,
         setAnswerEntryValue,
         savePossible,
         selectedQuestion,
@@ -64,7 +62,6 @@ export default function SheetEditor({ sheet, questions }: SheetEditorProps) {
         setOtherAnswers,
         setPending,
         setProposedQuestionText,
-        setQuestionFormValid,
         setSavePossible,
         setSelectedQuestion,
         sheetId,

--- a/src/app/vocab/[sheet]/context.ts
+++ b/src/app/vocab/[sheet]/context.ts
@@ -13,7 +13,6 @@ interface EditSheetContextType {
     otherAnswers: string[];
     pending: boolean;
     proposedQuestionText: string;
-    questionFormValid: boolean;
     setAnswerEntryValue: Dispatch<SetStateAction<string>>;
     savePossible: boolean;
     selectedQuestion: Question | null;
@@ -25,7 +24,6 @@ interface EditSheetContextType {
     setOtherAnswers: Dispatch<SetStateAction<string[]>>;
     setPending: Dispatch<SetStateAction<boolean>>;
     setProposedQuestionText: Dispatch<SetStateAction<string>>;
-    setQuestionFormValid: Dispatch<SetStateAction<boolean>>;
     setSavePossible: Dispatch<SetStateAction<boolean>>;
     setSelectedQuestion: Dispatch<SetStateAction<Question | null>>;
     sheetId: number;


### PR DESCRIPTION
It is best to calculate this in the component that uses validity, given that all information needed to determine this is available. Previously, there was a bug which incorrectly assessed a form to add a question as valid if an answer was typed in, even if no question text was entered.