### PR TITLE
Clearing other answers when creating a new question.

### DIFF
--- a/src/app/vocab/[sheet]/components/question-table/question-table.tsx
+++ b/src/app/vocab/[sheet]/components/question-table/question-table.tsx
@@ -114,6 +114,7 @@ export default function QuestionTable() {
         setIsAddingNewQuestion(true);
         setProposedQuestionText("");
         setAnswerEntryValue("");
+        setOtherAnswers([]);
         setIsEditingQuestionText(true);
         setProposedInflectionAnswers(new Map());
         setProposedInflectionType(null);


### PR DESCRIPTION
There was previously a bug where the answers from the previously selected question would not be cleared when the user clicked to add a new question.