### PR TITLE
Showing inflection tables without representative question.

### DIFF
--- a/src/app/components/inflection-template-proposal/inflection-template-proposal.tsx
+++ b/src/app/components/inflection-template-proposal/inflection-template-proposal.tsx
@@ -101,7 +101,10 @@ export default function InflectionTemplateProposal({
     };
 
     const cellContents = new Map<string, () => JSX.Element>();
-    for (const answer of representativeQuestion.inflectionAnswers) {
+    const answers = representativeQuestion
+        ? representativeQuestion.inflectionAnswers
+        : [];
+    for (const answer of answers) {
         const answerCellGenerator = () => <>{answer.answerText}</>;
         let keyForAnswerCell: string;
         if (answer.secondaryFeatureId === null) {


### PR DESCRIPTION
Previously, when a user proposed an inflection table that did not yet have any questions (such as when defining a new such table), there would be an error when rendering the example.