### PR TITLE
Making editable headers only blur when document still has focus.

### DIFF
--- a/src/app/components/editable-header/editable-header.tsx
+++ b/src/app/components/editable-header/editable-header.tsx
@@ -38,7 +38,7 @@ export default function EditableHeader({
     }
 
     const onBlurWithInputText = () => {
-        onBlur(inputText.trim());
+        if (document.hasFocus()) onBlur(inputText.trim());
     };
 
     function preventFormSubmission(e: React.KeyboardEvent<HTMLInputElement>) {


### PR DESCRIPTION
This allows users to, for example, switch their keyboard's language settings without the callback being triggered.