### PR TITLE
Using a unique editable header for each question.

### DIFF
--- a/src/app/vocab/[sheet]/components/question-editor/question-editor.tsx
+++ b/src/app/vocab/[sheet]/components/question-editor/question-editor.tsx
@@ -353,6 +353,7 @@ export default function QuestionEditor() {
     return (
         <form action={clickSaveQuestion}>
             <EditableHeader
+                key={selectedQuestion !== null ? selectedQuestion.id : null}
                 currentProposal={proposedQuestionText}
                 isEditing={isEditingQuestionText}
                 isPending={false}


### PR DESCRIPTION
This is because an editable header will not be deleted when switching from question to question. This led to the potential for a bug in which the text in the editable header was already set when trying to add a new question.